### PR TITLE
Update spotbugs dependency to 4.7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ configurations {
 }
 
 dependencies {
-    implementation ('com.github.spotbugs:spotbugs:4.7.3') {
+    implementation ('com.github.spotbugs:spotbugs:4.7.2') {
         exclude group: 'xml-apis', module: 'xml-apis'
     }
     implementation 'net.sf.saxon:Saxon-HE:9.9.1-2'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ configurations {
 }
 
 dependencies {
-    implementation ('com.github.spotbugs:spotbugs:4.4.2') {
+    implementation ('com.github.spotbugs:spotbugs:4.7.3') {
         exclude group: 'xml-apis', module: 'xml-apis'
     }
     implementation 'net.sf.saxon:Saxon-HE:9.9.1-2'


### PR DESCRIPTION
Just a dependency bump to get spotbugs up to the latest released verison.

@amaembo / @jqyp Thanks for maintaining this this plugin!

To avoid such PRs in the future, it may be worth considering adding a field to the GUI to allow users to set the spotbugs jar version.  Just a thought, but I appreciate you may not have the time!