### PR TITLE
Upgrade SpotBugs from 4.4.2 to 4.7.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ configurations {
 }
 
 dependencies {
-    implementation ('com.github.spotbugs:spotbugs:4.4.2') {
+    implementation ('com.github.spotbugs:spotbugs:4.7.3') {
         exclude group: 'xml-apis', module: 'xml-apis'
     }
     implementation 'net.sf.saxon:Saxon-HE:9.9.1-2'


### PR DESCRIPTION
Hello,
The current version of the plugin uses an old version of SpotBugs, this PR updates it to the latest (4.7.3)