### PR TITLE
Fix ActionUpdateThread deprecation error for IntelliJ 2024.x+

### DIFF
--- a/src/main/java/org/jetbrains/plugins/spotbugs/actions/AbstractAction.java
+++ b/src/main/java/org/jetbrains/plugins/spotbugs/actions/AbstractAction.java
@@ -19,6 +19,7 @@
  */
 package org.jetbrains.plugins.spotbugs.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -87,4 +88,9 @@ abstract class AbstractAction extends AnAction {
 			@NotNull final ToolWindow toolWindow,
 			@NotNull final FindBugsState state
 	);
+
+	@Override
+	public @NotNull ActionUpdateThread getActionUpdateThread() {
+		return ActionUpdateThread.EDT;
+	}
 }

--- a/src/main/java/org/jetbrains/plugins/spotbugs/actions/AbstractToggleAction.java
+++ b/src/main/java/org/jetbrains/plugins/spotbugs/actions/AbstractToggleAction.java
@@ -19,6 +19,7 @@
  */
 package org.jetbrains.plugins.spotbugs.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.ToggleAction;
 import com.intellij.openapi.module.Module;
@@ -185,4 +186,9 @@ abstract class AbstractToggleAction extends ToggleAction {
 			@NotNull final AbstractSettings settings,
 			boolean select
 	);
+
+	@Override
+	public @NotNull ActionUpdateThread getActionUpdateThread() {
+		return ActionUpdateThread.EDT;
+	}
 }


### PR DESCRIPTION
This PR fixes the deprecation of ActionUpdateThread.OLD_EDT, which causes errors like this in IntelliJ IDEA 2024.x+:
```
com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated and going to be removed soon. 'org.jetbrains.plugins.spotbugs.actions.ClearAndCloseToolWindow' must override `getActionUpdateThread()` and chose EDT or BGT. See ActionUpdateThread javadoc. [Plugin: org.jetbrains.plugins.spotbugs]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:90)
	at com.intellij.diagnostic.PluginException.reportDeprecatedUsage(PluginException.java:125)
	at com.intellij.openapi.actionSystem.ActionUpdateThreadAware.getActionUpdateThread(ActionUpdateThreadAware.java:21)
	at com.intellij.openapi.actionSystem.AnAction.getActionUpdateThread(AnAction.java:201)
```

To resolve this, I've overridden getActionUpdateThread() in AbstractAction and AbstractToggleAction, defaulting to EDT for actions that involve UI interactions. However, I haven’t extensively tested all actions, and feedback on whether some should run on BGT would be appreciated.

The fix is backwards compatible with IntelliJ IDEA 2022.2 (222.3345.118 build) and higher and should take care of the deprecation errors in 2024.x.